### PR TITLE
Sass sourcemap option removed

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -68,7 +68,7 @@ module.exports = function (grunt) {
     // Compiles Sass to CSS and generates necessary files if requested
     sass: {
       options: {
-        sourcemap: true,
+        //sourcemap: true,
         loadPath: 'bower_components'
       },
       dist: {


### PR DESCRIPTION
Fixes error “invalid option: --sourcemap” while running grunt serve.