### PR TITLE
always close drawer

### DIFF
--- a/app/elements/contacts-page/contacts-page.html
+++ b/app/elements/contacts-page/contacts-page.html
@@ -14,7 +14,7 @@
       <!-- Drawer -->
       <core-header-panel drawer mode="seamed">
         <core-toolbar>Menu</core-toolbar>
-        <core-menu selected="0" on-core-select="{{closeDrawer}}">
+        <core-menu selected="0" on-click="{{closeDrawer}}">
           <paper-item noink>
             <a href="/contacts/all" on-click="{{navigate}}">
               All Contacts


### PR DESCRIPTION
core-select event is fired only when you pick an item that is different then the one already selected. So when drawer is open in a small screen and e.g. "All Contacts" already rendered in main content you cannot close the drawer by clicking "All Contacts" once more. You have to click other item, like "Favorites" or "Circles". 
Not sure if that's a problem but I found that annoying :)