### PR TITLE
Fixed incorrect syntax on FilterProviders for apache >= 2.4.4

### DIFF
--- a/app/.htaccess
+++ b/app/.htaccess
@@ -164,27 +164,52 @@ AddType text/vtt                            vtt
   </IfModule>
 
   # HTML, TXT, CSS, JavaScript, JSON, XML, HTC:
-  <IfModule filter_module>
-    FilterDeclare   COMPRESS
-    FilterProvider  COMPRESS  DEFLATE resp=Content-Type $text/html
-    FilterProvider  COMPRESS  DEFLATE resp=Content-Type $text/css
-    FilterProvider  COMPRESS  DEFLATE resp=Content-Type $text/plain
-    FilterProvider  COMPRESS  DEFLATE resp=Content-Type $text/xml
-    FilterProvider  COMPRESS  DEFLATE resp=Content-Type $text/x-component
-    FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/javascript
-    FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/json
-    FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/xml
-    FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/xhtml+xml
-    FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/rss+xml
-    FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/atom+xml
-    FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/vnd.ms-fontobject
-    FilterProvider  COMPRESS  DEFLATE resp=Content-Type $image/svg+xml
-    FilterProvider  COMPRESS  DEFLATE resp=Content-Type $image/x-icon
-    FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/x-font-ttf
-    FilterProvider  COMPRESS  DEFLATE resp=Content-Type $font/opentype
-    FilterChain     COMPRESS
-    FilterProtocol  COMPRESS  DEFLATE change=yes;byteranges=no
-  </IfModule>
+  <IfVersion < 2.4.4>
+    <IfModule filter_module>
+      FilterDeclare   COMPRESS
+      FilterProvider  COMPRESS  DEFLATE resp=Content-Type $text/html
+      FilterProvider  COMPRESS  DEFLATE resp=Content-Type $text/css
+      FilterProvider  COMPRESS  DEFLATE resp=Content-Type $text/plain
+      FilterProvider  COMPRESS  DEFLATE resp=Content-Type $text/xml
+      FilterProvider  COMPRESS  DEFLATE resp=Content-Type $text/x-component
+      FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/javascript
+      FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/json
+      FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/xml
+      FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/xhtml+xml
+      FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/rss+xml
+      FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/atom+xml
+      FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/vnd.ms-fontobject
+      FilterProvider  COMPRESS  DEFLATE resp=Content-Type $image/svg+xml
+      FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/x-font-ttf
+      FilterProvider  COMPRESS  DEFLATE resp=Content-Type $font/opentype
+      FilterChain     COMPRESS
+      FilterProtocol  COMPRESS  DEFLATE change=yes;byteranges=no
+    </IfModule>
+  </IfVersion>
+
+  <IfVersion >= 2.4.4>
+    <IfModule filter_module>
+      FilterDeclare   COMPRESS
+      FilterProvider  COMPRESS  DEFLATE "%{Content_Type} = 'text/html'"
+      FilterProvider  COMPRESS  DEFLATE "%{Content_Type} = 'text/css'"
+      FilterProvider  COMPRESS  DEFLATE "%{Content_Type} = 'text/plain'"
+      FilterProvider  COMPRESS  DEFLATE "%{Content_Type} = 'text/xml'"
+      FilterProvider  COMPRESS  DEFLATE "%{Content_Type} = 'text/x-component'"
+      FilterProvider  COMPRESS  DEFLATE "%{Content_Type} = 'application/javascript'"
+      FilterProvider  COMPRESS  DEFLATE "%{Content_Type} = 'application/json'"
+      FilterProvider  COMPRESS  DEFLATE "%{Content_Type} = 'application/xml'"
+      FilterProvider  COMPRESS  DEFLATE "%{Content_Type} = 'application/xhtml+xml'"
+      FilterProvider  COMPRESS  DEFLATE "%{Content_Type} = 'application/rss+xml'"
+      FilterProvider  COMPRESS  DEFLATE "%{Content_Type} = 'application/atom+xml'"
+      FilterProvider  COMPRESS  DEFLATE "%{Content_Type} = 'application/vnd.ms-fontobject'"
+      FilterProvider  COMPRESS  DEFLATE "%{Content_Type} = 'image/svg+xml'"
+      FilterProvider  COMPRESS  DEFLATE "%{Content_Type} = 'image/x-icon'"
+      FilterProvider  COMPRESS  DEFLATE "%{Content_Type} = 'application/x-font-ttf'"
+      FilterProvider  COMPRESS  DEFLATE "%{Content_Type} = 'font/opentype'"
+      FilterChain     COMPRESS
+      FilterProtocol  COMPRESS  DEFLATE change=yes;byteranges=no
+    </IfModule>
+  </IfVersion>
 
   <IfModule !mod_filter.c>
     # Legacy versions of Apache

--- a/app/index.html
+++ b/app/index.html
@@ -34,12 +34,12 @@
       && 'content' in document.createElement('template')) {
       // We're using a browser with native WC support!
     } else {
-      document.write('<script src="/bower_components/webcomponentsjs/webcomponents.js"><\/script>');
+      document.write('<script src="./bower_components/webcomponentsjs/webcomponents.js"><\/script>');
     }
   </script>
 
   <!-- build:vulcanized /elements/elements.critical.vulcanized.html -->
-  <link rel="import" href="/elements/elements.critical.html">
+  <link rel="import" href="./elements/elements.critical.html">
   <!-- endbuild-->
 </head>
 
@@ -86,8 +86,8 @@
   </template>
 
   <!-- build:js /scripts/app.js -->
-  <script src="/bower_components/director/build/director.js"></script>
-  <script src="/scripts/app.js"></script>
+  <script src="./bower_components/director/build/director.js"></script>
+  <script src="./scripts/app.js"></script>
   <!-- endbuild-->
 </body>
 


### PR DESCRIPTION
FilterProvider dispatch match syntax changed on apache 2.4.4 and above.

Fixes 500 Internal Server error on using old syntax when new syntax is expected.