### PR TITLE
Fixed incorrect syntax on FilterProviders for apache >= 2.4.4

### DIFF
--- a/app/.htaccess
+++ b/app/.htaccess
@@ -164,27 +164,52 @@ AddType text/vtt                            vtt
   </IfModule>
 
   # HTML, TXT, CSS, JavaScript, JSON, XML, HTC:
-  <IfModule filter_module>
-    FilterDeclare   COMPRESS
-    FilterProvider  COMPRESS  DEFLATE resp=Content-Type $text/html
-    FilterProvider  COMPRESS  DEFLATE resp=Content-Type $text/css
-    FilterProvider  COMPRESS  DEFLATE resp=Content-Type $text/plain
-    FilterProvider  COMPRESS  DEFLATE resp=Content-Type $text/xml
-    FilterProvider  COMPRESS  DEFLATE resp=Content-Type $text/x-component
-    FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/javascript
-    FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/json
-    FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/xml
-    FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/xhtml+xml
-    FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/rss+xml
-    FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/atom+xml
-    FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/vnd.ms-fontobject
-    FilterProvider  COMPRESS  DEFLATE resp=Content-Type $image/svg+xml
-    FilterProvider  COMPRESS  DEFLATE resp=Content-Type $image/x-icon
-    FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/x-font-ttf
-    FilterProvider  COMPRESS  DEFLATE resp=Content-Type $font/opentype
-    FilterChain     COMPRESS
-    FilterProtocol  COMPRESS  DEFLATE change=yes;byteranges=no
-  </IfModule>
+  <IfVersion < 2.4.4>
+    <IfModule filter_module>
+      FilterDeclare   COMPRESS
+      FilterProvider  COMPRESS  DEFLATE resp=Content-Type $text/html
+      FilterProvider  COMPRESS  DEFLATE resp=Content-Type $text/css
+      FilterProvider  COMPRESS  DEFLATE resp=Content-Type $text/plain
+      FilterProvider  COMPRESS  DEFLATE resp=Content-Type $text/xml
+      FilterProvider  COMPRESS  DEFLATE resp=Content-Type $text/x-component
+      FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/javascript
+      FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/json
+      FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/xml
+      FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/xhtml+xml
+      FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/rss+xml
+      FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/atom+xml
+      FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/vnd.ms-fontobject
+      FilterProvider  COMPRESS  DEFLATE resp=Content-Type $image/svg+xml
+      FilterProvider  COMPRESS  DEFLATE resp=Content-Type $application/x-font-ttf
+      FilterProvider  COMPRESS  DEFLATE resp=Content-Type $font/opentype
+      FilterChain     COMPRESS
+      FilterProtocol  COMPRESS  DEFLATE change=yes;byteranges=no
+    </IfModule>
+  </IfVersion>
+
+  <IfVersion >= 2.4.4>
+    <IfModule filter_module>
+      FilterDeclare   COMPRESS
+      FilterProvider  COMPRESS  DEFLATE "%{Content_Type} = 'text/html'"
+      FilterProvider  COMPRESS  DEFLATE "%{Content_Type} = 'text/css'"
+      FilterProvider  COMPRESS  DEFLATE "%{Content_Type} = 'text/plain'"
+      FilterProvider  COMPRESS  DEFLATE "%{Content_Type} = 'text/xml'"
+      FilterProvider  COMPRESS  DEFLATE "%{Content_Type} = 'text/x-component'"
+      FilterProvider  COMPRESS  DEFLATE "%{Content_Type} = 'application/javascript'"
+      FilterProvider  COMPRESS  DEFLATE "%{Content_Type} = 'application/json'"
+      FilterProvider  COMPRESS  DEFLATE "%{Content_Type} = 'application/xml'"
+      FilterProvider  COMPRESS  DEFLATE "%{Content_Type} = 'application/xhtml+xml'"
+      FilterProvider  COMPRESS  DEFLATE "%{Content_Type} = 'application/rss+xml'"
+      FilterProvider  COMPRESS  DEFLATE "%{Content_Type} = 'application/atom+xml'"
+      FilterProvider  COMPRESS  DEFLATE "%{Content_Type} = 'application/vnd.ms-fontobject'"
+      FilterProvider  COMPRESS  DEFLATE "%{Content_Type} = 'image/svg+xml'"
+      FilterProvider  COMPRESS  DEFLATE "%{Content_Type} = 'image/x-icon'"
+      FilterProvider  COMPRESS  DEFLATE "%{Content_Type} = 'application/x-font-ttf'"
+      FilterProvider  COMPRESS  DEFLATE "%{Content_Type} = 'font/opentype'"
+      FilterChain     COMPRESS
+      FilterProtocol  COMPRESS  DEFLATE change=yes;byteranges=no
+    </IfModule>
+  </IfVersion>
 
   <IfModule !mod_filter.c>
     # Legacy versions of Apache


### PR DESCRIPTION
FilterProvider dispatch match syntax changed on apache 2.4.4 and above.

Fixes 500 Internal Server error on using old syntax when new syntax is expected.